### PR TITLE
Remove erroneous whitespace from beginning of group name

### DIFF
--- a/QvWebTicket/TicketResponse.cs
+++ b/QvWebTicket/TicketResponse.cs
@@ -113,7 +113,7 @@ namespace QvWebTicket
             if (groups.Length > 0)
             {
                 groupsXml.Append("<GroupList>");
-                groupsXml.Append(String.Join("", groups.Select(x => "<string> " + x + "</string>")));
+                groupsXml.Append(String.Join("", groups.Select(x => "<string>" + x + "</string>")));
                 groupsXml.Append("</GroupList><GroupsIsNames>true</GroupsIsNames>");
             }
 


### PR DESCRIPTION
When creating a ticket a space is added before each group name in the xml.
Which leads to no documents being displayed in the AccessPoint